### PR TITLE
Add CRD CRUD utilities with tests

### DIFF
--- a/Controller/crd_crud.py
+++ b/Controller/crd_crud.py
@@ -1,0 +1,152 @@
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+# Default CRD configuration used by the controller
+CRD_GROUP = "ha.example.com"
+CRD_VERSION = "v1"
+CRD_NAMESPACE = "default"
+
+SERVICE_PLURAL = "services"
+SERVICE_NAME = "service-info"
+
+SERVICESPEC_PLURAL = "servicespecs"
+SERVICESPEC_NAME = "servicespec-info"
+
+SUBSCRIPTION_PLURAL = "subscriptions"
+SUBSCRIPTION_NAME = "subscription-info"
+
+NODESTATUS_PLURAL = "nodestatuses"
+NODESTATUS_NAME = "nodestatus-info"
+
+IN_CLUSTER = True
+
+
+def _load_config():
+    """Load the Kubernetes config depending on environment."""
+    if IN_CLUSTER:
+        config.load_incluster_config()
+    else:
+        config.load_kube_config()
+
+
+def _get_api() -> client.CustomObjectsApi:
+    """Return a CustomObjectsApi instance."""
+    _load_config()
+    return client.CustomObjectsApi()
+
+
+def create_crd(plural: str, name: str, data: dict):
+    """Create a custom resource."""
+    api = _get_api()
+    body = {
+        "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
+        "kind": "Data",
+        "metadata": {"name": name},
+        "data": data,
+    }
+    return api.create_namespaced_custom_object(
+        CRD_GROUP, CRD_VERSION, CRD_NAMESPACE, plural, body
+    )
+
+
+def read_crd(plural: str, name: str):
+    """Read a custom resource and return the stored data or None."""
+    api = _get_api()
+    try:
+        obj = api.get_namespaced_custom_object(
+            CRD_GROUP, CRD_VERSION, CRD_NAMESPACE, plural, name
+        )
+        return obj.get("data")
+    except ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
+def update_crd(plural: str, name: str, data: dict):
+    """Replace the custom resource with new data."""
+    api = _get_api()
+    body = {
+        "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
+        "kind": "Data",
+        "metadata": {"name": name},
+        "data": data,
+    }
+    return api.replace_namespaced_custom_object(
+        CRD_GROUP, CRD_VERSION, CRD_NAMESPACE, plural, name, body
+    )
+
+
+def delete_crd(plural: str, name: str):
+    """Delete a custom resource."""
+    api = _get_api()
+    return api.delete_namespaced_custom_object(
+        CRD_GROUP, CRD_VERSION, CRD_NAMESPACE, plural, name
+    )
+
+
+def create_service(data: dict):
+    return create_crd(SERVICE_PLURAL, SERVICE_NAME, data)
+
+
+def get_service():
+    return read_crd(SERVICE_PLURAL, SERVICE_NAME)
+
+
+def update_service(data: dict):
+    return update_crd(SERVICE_PLURAL, SERVICE_NAME, data)
+
+
+def delete_service():
+    return delete_crd(SERVICE_PLURAL, SERVICE_NAME)
+
+
+# Similar helper wrappers for other CRDs
+
+def create_servicespec(data: dict):
+    return create_crd(SERVICESPEC_PLURAL, SERVICESPEC_NAME, data)
+
+
+def get_servicespec():
+    return read_crd(SERVICESPEC_PLURAL, SERVICESPEC_NAME)
+
+
+def update_servicespec(data: dict):
+    return update_crd(SERVICESPEC_PLURAL, SERVICESPEC_NAME, data)
+
+
+def delete_servicespec():
+    return delete_crd(SERVICESPEC_PLURAL, SERVICESPEC_NAME)
+
+
+def create_subscription(data: dict):
+    return create_crd(SUBSCRIPTION_PLURAL, SUBSCRIPTION_NAME, data)
+
+
+def get_subscription():
+    return read_crd(SUBSCRIPTION_PLURAL, SUBSCRIPTION_NAME)
+
+
+def update_subscription(data: dict):
+    return update_crd(SUBSCRIPTION_PLURAL, SUBSCRIPTION_NAME, data)
+
+
+def delete_subscription():
+    return delete_crd(SUBSCRIPTION_PLURAL, SUBSCRIPTION_NAME)
+
+
+def create_nodestatus(data: dict):
+    return create_crd(NODESTATUS_PLURAL, NODESTATUS_NAME, data)
+
+
+def get_nodestatus():
+    return read_crd(NODESTATUS_PLURAL, NODESTATUS_NAME)
+
+
+def update_nodestatus(data: dict):
+    return update_crd(NODESTATUS_PLURAL, NODESTATUS_NAME, data)
+
+
+def delete_nodestatus():
+    return delete_crd(NODESTATUS_PLURAL, NODESTATUS_NAME)
+

--- a/Controller/test_crd_crud.py
+++ b/Controller/test_crd_crud.py
@@ -1,0 +1,94 @@
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Provide a minimal kubernetes module when the real package is not available
+if 'kubernetes' not in sys.modules:
+    kubernetes = types.ModuleType('kubernetes')
+    kubernetes.client = types.ModuleType('client')
+    kubernetes.config = types.ModuleType('config')
+    kubernetes.client.rest = types.ModuleType('rest')
+    kubernetes.client.rest.ApiException = Exception
+    class CustomObjectsApi:
+        pass
+    kubernetes.client.CustomObjectsApi = CustomObjectsApi
+    sys.modules['kubernetes'] = kubernetes
+    sys.modules['kubernetes.client'] = kubernetes.client
+    sys.modules['kubernetes.config'] = kubernetes.config
+    sys.modules['kubernetes.client.rest'] = kubernetes.client.rest
+
+import crd_crud
+
+CRD_GROUP = crd_crud.CRD_GROUP
+CRD_VERSION = crd_crud.CRD_VERSION
+CRD_NAMESPACE = crd_crud.CRD_NAMESPACE
+
+
+class CrudTestCase(unittest.TestCase):
+    def setUp(self):
+        self.api_mock = MagicMock()
+        patcher = patch('crd_crud._get_api', return_value=self.api_mock)
+        self.get_api = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_create_crd(self):
+        data = {'foo': 'bar'}
+        crd_crud.create_crd('services', 'test', data)
+        expected_body = {
+            'apiVersion': f'{CRD_GROUP}/{CRD_VERSION}',
+            'kind': 'Data',
+            'metadata': {'name': 'test'},
+            'data': data,
+        }
+        self.api_mock.create_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            CRD_NAMESPACE,
+            'services',
+            expected_body,
+        )
+
+    def test_read_crd(self):
+        self.api_mock.get_namespaced_custom_object.return_value = {'data': {'k': 'v'}}
+        result = crd_crud.read_crd('services', 'test')
+        self.api_mock.get_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            CRD_NAMESPACE,
+            'services',
+            'test',
+        )
+        self.assertEqual(result, {'k': 'v'})
+
+    def test_update_crd(self):
+        data = {'k': 'v'}
+        crd_crud.update_crd('services', 'test', data)
+        expected_body = {
+            'apiVersion': f'{CRD_GROUP}/{CRD_VERSION}',
+            'kind': 'Data',
+            'metadata': {'name': 'test'},
+            'data': data,
+        }
+        self.api_mock.replace_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            CRD_NAMESPACE,
+            'services',
+            'test',
+            expected_body,
+        )
+
+    def test_delete_crd(self):
+        crd_crud.delete_crd('services', 'test')
+        self.api_mock.delete_namespaced_custom_object.assert_called_once_with(
+            CRD_GROUP,
+            CRD_VERSION,
+            CRD_NAMESPACE,
+            'services',
+            'test',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `crd_crud.py` to manage controller CRDs
- provide unit tests that mock the Kubernetes client

## Testing
- `python Controller/test_crd_crud.py`

------
https://chatgpt.com/codex/tasks/task_e_68880bf777188331ad37e787298c8246