### PR TITLE
Add SyncManager Docker setup and deployment examples

### DIFF
--- a/SyncManager/Dockerfile
+++ b/SyncManager/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python"]

--- a/SyncManager/requirements.txt
+++ b/SyncManager/requirements.txt
@@ -1,0 +1,4 @@
+kubernetes
+watchdog
+requests
+pyyaml

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sync-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sync-manager
+  template:
+    metadata:
+      labels:
+        app: sync-manager
+    spec:
+      serviceAccountName: sync-manager-sa
+      containers:
+      - name: main
+        image: example/main:latest
+        volumeMounts:
+        - name: service-info
+          mountPath: /data/service-info.json
+          subPath: service-info.json
+      - name: sidecar
+        image: example/sidecar:latest
+        volumeMounts:
+        - name: service-info
+          mountPath: /data/service-info.json
+          subPath: service-info.json
+      volumes:
+      - name: service-info
+        emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sync-manager-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sync-manager-role
+rules:
+- apiGroups: ["ha.example.com"]
+  resources: ["services"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sync-manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: sync-manager-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sync-manager-role

--- a/deploy/sync-targets-configmap.yaml
+++ b/deploy/sync-targets-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sync-manager-targets
+data:
+  targets: |
+    - name: cluster-a
+      url: https://cluster-a.example.com
+    - name: cluster-b
+      url: https://cluster-b.example.com


### PR DESCRIPTION
## Summary
- add Dockerfile and Python requirements for new SyncManager component
- include example Kubernetes deployment with shared volume and RBAC for services.ha.example.com
- provide ConfigMap for configuring multiple sync targets

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689028c33f208331a9b5a9bae848e2d3