### PR TITLE
Add CRD syncer sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ crashloopbackoff.yaml
 gesture.yaml
 objecton25.yaml
 values.yaml
+__pycache__/
+*.pyc

--- a/Syncer/Dockerfile
+++ b/Syncer/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY crd_syncer.py .
+ENV PYTHONUNBUFFERED=1
+CMD ["python", "crd_syncer.py"]

--- a/Syncer/README.md
+++ b/Syncer/README.md
@@ -1,0 +1,18 @@
+# CRD Syncer
+
+This sidecar component synchronizes local JSON files with Kubernetes custom resources.
+
+## Environment variables
+
+- `FILE_MAP`: newline separated mappings in the form `file_path=plural:name`.
+- `CRD_GROUP`: CRD API group (e.g. `ha.example.com`).
+- `CRD_VERSION`: CRD API version (e.g. `v1`).
+- `NAMESPACE`: namespace of the custom resources. Defaults to `default`.
+- `IN_CLUSTER`: set to `true` when running inside a cluster.
+- `SYNC_INTERVAL`: polling interval in seconds. Defaults to 5.
+
+## Usage
+
+The syncer keeps files and CRs in sync in both directions using MD5 hashes to
+avoid feedback loops. An example deployment using an `emptyDir` volume is
+available in the project documentation.

--- a/Syncer/crd_syncer.py
+++ b/Syncer/crd_syncer.py
@@ -1,0 +1,132 @@
+import os
+import time
+import json
+import hashlib
+import logging
+from typing import Dict, Tuple
+
+from kubernetes import client, config
+from kubernetes.client import ApiException
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+def load_kube_config() -> None:
+    """Load Kubernetes configuration based on IN_CLUSTER flag."""
+    in_cluster = os.environ.get("IN_CLUSTER", "false").lower() == "true"
+    if in_cluster:
+        config.load_incluster_config()
+    else:
+        config.load_kube_config()
+
+
+def parse_file_map(raw: str) -> Dict[str, Tuple[str, str]]:
+    """Parse FILE_MAP env into mapping {filepath: (plural, name)}."""
+    mapping: Dict[str, Tuple[str, str]] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            path, target = line.split("=")
+            plural, name = target.split(":")
+            mapping[path] = (plural, name)
+        except ValueError:
+            logging.warning("Invalid FILE_MAP entry: %s", line)
+    return mapping
+
+
+def md5sum(data: str) -> str:
+    return hashlib.md5(data.encode("utf-8")).hexdigest()
+
+
+def ensure_cr(api: client.CustomObjectsApi, group: str, version: str,
+              namespace: str, plural: str, name: str) -> Dict:
+    """Ensure the custom resource exists, return its body."""
+    try:
+        return api.get_namespaced_custom_object(group, version, namespace, plural, name)
+    except ApiException as e:
+        if e.status == 404:
+            body = {
+                "apiVersion": f"{group}/{version}",
+                "kind": "Data",
+                "metadata": {"name": name},
+                "spec": {"data": {}}
+            }
+            api.create_namespaced_custom_object(group, version, namespace, plural, body)
+            logging.info("Created %s/%s", plural, name)
+            return body
+        raise
+
+
+def get_cr_data(body: Dict) -> Dict:
+    return body.get("spec", {}).get("data", {})
+
+
+def sync_loop():
+    file_map_raw = os.environ.get("FILE_MAP", "")
+    if not file_map_raw:
+        raise RuntimeError("FILE_MAP env is required")
+    mappings = parse_file_map(file_map_raw)
+
+    group = os.environ.get("CRD_GROUP", "ha.example.com")
+    version = os.environ.get("CRD_VERSION", "v1")
+    namespace = os.environ.get("NAMESPACE", "default")
+    interval = float(os.environ.get("SYNC_INTERVAL", "5"))
+
+    api = client.CustomObjectsApi()
+
+    state: Dict[str, Dict[str, str]] = {}
+    for path, (plural, name) in mappings.items():
+        body = ensure_cr(api, group, version, namespace, plural, name)
+        cr_md5 = md5sum(json.dumps(get_cr_data(body), sort_keys=True))
+        if os.path.exists(path):
+            with open(path) as f:
+                content = f.read()
+        else:
+            content = json.dumps({}, indent=2, sort_keys=True)
+            with open(path, "w") as f:
+                f.write(content)
+        file_md5 = md5sum(content)
+        state[path] = {"file_md5": file_md5, "cr_md5": cr_md5}
+
+    while True:
+        for path, (plural, name) in mappings.items():
+            st = state[path]
+
+            # read file
+            try:
+                with open(path) as f:
+                    file_content = f.read()
+            except FileNotFoundError:
+                file_content = json.dumps({}, indent=2, sort_keys=True)
+                with open(path, "w") as f:
+                    f.write(file_content)
+            file_md5 = md5sum(file_content)
+
+            # read CR
+            body = api.get_namespaced_custom_object(group, version, namespace, plural, name)
+            cr_content = json.dumps(get_cr_data(body), indent=2, sort_keys=True)
+            cr_md5 = md5sum(cr_content)
+
+            if file_md5 != st["file_md5"] and file_md5 != st["cr_md5"]:
+                # file changed -> update CR
+                logging.info("%s changed, updating CR %s/%s", path, plural, name)
+                patch_body = {"spec": {"data": json.loads(file_content)}}
+                api.patch_namespaced_custom_object(group, version, namespace, plural, name, patch_body)
+                st["file_md5"] = file_md5
+                st["cr_md5"] = file_md5
+            elif cr_md5 != st["cr_md5"] and cr_md5 != st["file_md5"]:
+                # CR changed -> update file
+                logging.info("CR %s/%s changed, writing to %s", plural, name, path)
+                with open(path, "w") as f:
+                    f.write(cr_content)
+                st["file_md5"] = cr_md5
+                st["cr_md5"] = cr_md5
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    load_kube_config()
+    sync_loop()

--- a/Syncer/requirements.txt
+++ b/Syncer/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes

--- a/doc/syncer_spec.md
+++ b/doc/syncer_spec.md
@@ -1,0 +1,81 @@
+# Syncer Development Specification
+
+## Project Goal
+
+Build a sidecar component that keeps local JSON files used by the existing controller
+in sync with Kubernetes custom resources (CRs) without modifying the controller logic.
+
+## Files Operated by the Controller
+
+```
+Controller/information/
+├── nodestatus.json
+├── service.json
+├── serviceSpec.json
+└── subscription.json
+```
+
+## Synchronization Targets
+
+| File | CRD | CR Name | Plural |
+| ---- | --- | ------- | ------ |
+| `service.json` | `Data` in `services.ha.example.com/v1` | `service-info` | `services` |
+| `serviceSpec.json` | `Data` in `servicespecs.ha.example.com/v1` | `servicespec-info` | `servicespecs` |
+| `subscription.json` | `Data` in `subscriptions.ha.example.com/v1` | `subscription-info` | `subscriptions` |
+| `nodestatus.json` | `Data` in `nodestatuses.ha.example.com/v1` | `nodestatus-info` | `nodestatuses` |
+
+## Synchronization Behavior
+
+- Changes to local files update the corresponding CR.
+- External changes to a CR are written back to the local file.
+- MD5 hashes detect differences and prevent feedback loops.
+- On startup, the syncer creates empty CRs when they do not exist.
+
+## Deployment
+
+Deploy the syncer as a sidecar sharing an `emptyDir` volume with the controller. Example:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-with-syncer
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ha-controller
+  template:
+    metadata:
+      labels:
+        app: ha-controller
+    spec:
+      volumes:
+        - name: shared-data
+          emptyDir: {}
+      containers:
+        - name: controller
+          image: your-controller-image:latest
+          volumeMounts:
+            - mountPath: /data
+              name: shared-data
+        - name: crd-syncer
+          image: your-crd-syncer-image:latest
+          env:
+            - name: FILE_MAP
+              value: |
+                /data/service.json=services:service-info
+                /data/serviceSpec.json=servicespecs:servicespec-info
+                /data/subscription.json=subscriptions:subscription-info
+                /data/nodestatus.json=nodestatuses:nodestatus-info
+            - name: CRD_GROUP
+              value: ha.example.com
+            - name: CRD_VERSION
+              value: v1
+            - name: IN_CLUSTER
+              value: "true"
+          volumeMounts:
+            - mountPath: /data
+              name: shared-data
+```


### PR DESCRIPTION
## Summary
- add Python-based syncer to mirror controller JSON files with custom resources
- document syncer configuration and example deployment
- include Dockerfile and requirements for building syncer image

## Testing
- `python -m py_compile Syncer/crd_syncer.py`


------
https://chatgpt.com/codex/tasks/task_e_6890a471c1dc8331913fdd43f8de7174