### PR TITLE
Add CRD Syncer sidecar to controller deployment

### DIFF
--- a/Controller/controller-deployment.yaml
+++ b/Controller/controller-deployment.yaml
@@ -35,23 +35,43 @@ spec:
           volumeMounts:
             - name: information
               mountPath: /app/information
-      volumes:
-        - name: information
-          persistentVolumeClaim:
-            claimName: arha-system-information
-        - name: logs-volume
-          persistentVolumeClaim:
-            claimName: arha-logs-pvc
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: arha-node-type
-                operator: In
-                values:
-                - controller-node
-      tolerations:
-        - key: "node-role.kubernetes.io/control-plane"
-          operator: "Exists"
-          effect: "NoSchedule"
+        - name: crd-syncer
+          image: harbor.pdc.tw/arha/syncer:latest
+          env:
+            - name: FILE_MAP
+              value: |
+                /app/information/service.json=services:service-info
+                /app/information/serviceSpec.json=servicespecs:servicespec-info
+                /app/information/subscription.json=subscriptions:subscription-info
+                /app/information/nodestatus.json=nodestatuses:nodestatus-info
+            - name: CRD_GROUP
+              value: ha.example.com
+            - name: CRD_VERSION
+              value: v1
+            - name: NAMESPACE
+              value: arha-system
+            - name: IN_CLUSTER
+              value: "true"
+          volumeMounts:
+            - name: information
+              mountPath: /app/information
+        volumes:
+          - name: information
+            persistentVolumeClaim:
+              claimName: arha-system-information
+          - name: logs-volume
+            persistentVolumeClaim:
+              claimName: arha-logs-pvc
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: arha-node-type
+                  operator: In
+                  values:
+                  - controller-node
+        tolerations:
+          - key: "node-role.kubernetes.io/control-plane"
+            operator: "Exists"
+            effect: "NoSchedule"


### PR DESCRIPTION
## Summary
- add `crd-syncer` container to controller deployment
- configure file-to-CR mapping and required environment variables
- mount existing information volume for syncer

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6891333807dc8331a2e38506e3bd74a5