### PR TITLE
Add CRD definitions and update Syncer docs

### DIFF
--- a/Syncer/README.md
+++ b/Syncer/README.md
@@ -1,14 +1,22 @@
 CRD Syncer
 此 sidecar 元件負責將本地 JSON 檔案與 Kubernetes 自訂資源進行同步。
 
+在部署 Syncer 前，請先安裝所需的 CRD：
+
+```bash
+kubectl apply -f k8s/crd/
+```
+
 環境變數
 
-* **FILE\_MAP**：以換行分隔的對應關係，格式為 `file_path=plural:name`。
-* **CRD\_GROUP**：CRD 的 API group（例如 ha.example.com）。
-* **CRD\_VERSION**：CRD 的 API 版本（例如 v1）。
+* **FILE_MAP**：以換行分隔的對應關係，格式為 `file_path=plural:name`。
+* **CRD_GROUP**：CRD 的 API group（例如 ha.example.com）。
+* **CRD_VERSION**：CRD 的 API 版本（例如 v1）。
 * **NAMESPACE**：自訂資源所屬的命名空間，預設為 default。
-* **IN\_CLUSTER**：在叢集內執行時設為 true。
-* **SYNC\_INTERVAL**：輪詢間隔秒數，預設為 5。
+* **IN_CLUSTER**：在叢集內執行時設為 true。
+* **SYNC_INTERVAL**：輪詢間隔秒數，預設為 5。
+
+如叢集中已存在相同名稱但 API group 不同的 CRD，請調整 `CRD_GROUP` 或 `FILE_MAP` 使其與實際資源相符。
 
 用法
 Syncer 會使用 MD5 雜湊值，雙向同步檔案與 CR，避免同步時發生回饋迴圈。

--- a/k8s/crd/nodestatuses.yaml
+++ b/k8s/crd/nodestatuses.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodestatuses.ha.example.com
+spec:
+  group: ha.example.com
+  names:
+    plural: nodestatuses
+    singular: nodestatus
+    kind: NodeStatus
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/k8s/crd/services.yaml
+++ b/k8s/crd/services.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: services.ha.example.com
+spec:
+  group: ha.example.com
+  names:
+    plural: services
+    singular: service
+    kind: Service
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/k8s/crd/servicespecs.yaml
+++ b/k8s/crd/servicespecs.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: servicespecs.ha.example.com
+spec:
+  group: ha.example.com
+  names:
+    plural: servicespecs
+    singular: servicespec
+    kind: ServiceSpec
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/k8s/crd/subscriptions.yaml
+++ b/k8s/crd/subscriptions.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.ha.example.com
+spec:
+  group: ha.example.com
+  names:
+    plural: subscriptions
+    singular: subscription
+    kind: Subscription
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true


### PR DESCRIPTION
## Summary
- add CRDs for Service, ServiceSpec, Subscription, and NodeStatus under ha.example.com
- document CRD installation and env var alignment in Syncer README

## Testing
- `python -m py_compile Syncer/crd_syncer.py`


------
https://chatgpt.com/codex/tasks/task_e_68919dcb4b7883318bb853b7f4fa310e