### PR TITLE
Add openAPIV3 schemas for HA CRDs

### DIFF
--- a/k8s/crd/nodestatuses.yaml
+++ b/k8s/crd/nodestatuses.yaml
@@ -13,3 +13,13 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/k8s/crd/services.yaml
+++ b/k8s/crd/services.yaml
@@ -13,3 +13,13 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/k8s/crd/servicespecs.yaml
+++ b/k8s/crd/servicespecs.yaml
@@ -13,3 +13,13 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/k8s/crd/subscriptions.yaml
+++ b/k8s/crd/subscriptions.yaml
@@ -13,3 +13,13 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Summary
- add minimal openAPIV3 schema definitions for NodeStatus, Service, ServiceSpec, and Subscription CRDs

## Testing
- `kubectl apply -f k8s/crd/` *(fails: command not found: kubectl)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891a77cc2748331904530636f6c3463