### PR TITLE
Add lightweight CRD syncer for JSON files

### DIFF
--- a/crd-syncer/.github/workflows/ci.yaml
+++ b/crd-syncer/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r crd-syncer/requirements.txt
+      - name: Run tests
+        run: |
+          PYTHONPATH=crd-syncer pytest -q

--- a/crd-syncer/Dockerfile
+++ b/crd-syncer/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY syncer ./syncer
+CMD ["python", "-m", "syncer.main"]

--- a/crd-syncer/LICENSE
+++ b/crd-syncer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 CRD Syncer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crd-syncer/README.md
+++ b/crd-syncer/README.md
@@ -1,0 +1,44 @@
+# CRD Syncer
+
+A lightweight synchronizer that keeps JSON state files and Kubernetes custom resources (CRs) in sync. Existing applications can continue using local JSON files while the syncer mirrors changes to Kubernetes.
+
+## Installation
+
+### Helm (optional)
+```bash
+helm install crd-syncer ./charts
+```
+
+### kubectl
+```bash
+kubectl apply -f deployment.yaml
+```
+
+### Docker
+```bash
+docker build -t crd-syncer .
+docker run --rm -e FILE_MAP="/data/state.json=states:example" \
+  -v $(pwd)/data:/data crd-syncer
+```
+
+## Quick Start
+1. Deploy the [CRD](examples/crd.yaml).
+2. Deploy the syncer using the [example deployment](examples/deployment.yaml) or the provided `deployment.yaml`.
+3. Write to your JSON file and watch the corresponding Custom Resource update automatically.
+
+## Customizing Sync Rules
+`FILE_MAP` defines mappings between files and Custom Resources. Each line follows:
+```
+/path/file.json=plural:name
+```
+Multiple mappings are supported using newlines.
+
+## Examples
+See the [examples](examples) directory for a sample CRD and deployment manifest.
+
+## Troubleshooting
+* Ensure the CRD exists and the syncer has RBAC permissions to read/write it.
+* Verify the `FILE_MAP` paths are mounted inside the container.
+
+## License
+[MIT](LICENSE)

--- a/crd-syncer/charts/README.md
+++ b/crd-syncer/charts/README.md
@@ -1,0 +1,3 @@
+# Helm Charts
+
+Placeholder for Helm chart.

--- a/crd-syncer/deployment.yaml
+++ b/crd-syncer/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crd-syncer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crd-syncer
+  template:
+    metadata:
+      labels:
+        app: crd-syncer
+    spec:
+      containers:
+        - name: syncer
+          image: ghcr.io/example/crd-syncer:latest
+          envFrom:
+            - configMapRef:
+                name: crd-syncer-config
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/crd-syncer/docs/README.md
+++ b/crd-syncer/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Additional project documentation goes here.

--- a/crd-syncer/examples/crd.yaml
+++ b/crd-syncer/examples/crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: states.ha.example.com
+spec:
+  group: ha.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+  scope: Namespaced
+  names:
+    plural: states
+    singular: state
+    kind: State

--- a/crd-syncer/examples/deployment.yaml
+++ b/crd-syncer/examples/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crd-syncer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crd-syncer
+  template:
+    metadata:
+      labels:
+        app: crd-syncer
+    spec:
+      containers:
+        - name: syncer
+          image: ghcr.io/example/crd-syncer:latest
+          env:
+            - name: FILE_MAP
+              value: "/data/state.json=states:example"
+            - name: CRD_GROUP
+              value: ha.example.com
+            - name: CRD_VERSION
+              value: v1
+            - name: CRD_NAMESPACE
+              value: default
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/crd-syncer/requirements.txt
+++ b/crd-syncer/requirements.txt
@@ -1,0 +1,2 @@
+kubernetes>=26.1.0
+pytest

--- a/crd-syncer/syncer/main.py
+++ b/crd-syncer/syncer/main.py
@@ -1,0 +1,136 @@
+import os
+import json
+import time
+import hashlib
+import logging
+from pathlib import Path
+from typing import Dict, Tuple
+
+from kubernetes import client, config
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s [%(levelname)s] %(message)s')
+
+
+def load_kube_config(in_cluster: bool) -> None:
+    if in_cluster:
+        config.load_incluster_config()
+    else:
+        config.load_kube_config()
+
+
+def parse_file_map(env: str) -> Dict[str, Tuple[str, str]]:
+    mapping: Dict[str, Tuple[str, str]] = {}
+    for line in env.strip().splitlines():
+        if not line:
+            continue
+        path, target = line.split('=')
+        plural, name = target.split(':')
+        mapping[path] = (plural, name)
+    return mapping
+
+
+def md5_bytes(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()
+
+
+def hash_dict(d: Dict) -> str:
+    return md5_bytes(json.dumps(d, sort_keys=True).encode())
+
+
+class FileCRSyncer:
+    def __init__(self, file_map: Dict[str, Tuple[str, str]], api: client.CustomObjectsApi,
+                 group: str, version: str, namespace: str, interval: int = 5) -> None:
+        self.file_map = file_map
+        self.api = api
+        self.group = group
+        self.version = version
+        self.namespace = namespace
+        self.interval = interval
+        self.state = {path: {'file': None, 'cr': None} for path in file_map}
+
+    def load_file(self, path: str) -> Dict:
+        try:
+            with open(path, 'r') as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return {}
+
+    def write_file(self, path: str, data: Dict) -> None:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, 'w') as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+
+    def read_cr(self, plural: str, name: str) -> Dict:
+        try:
+            return self.api.get_namespaced_custom_object(
+                self.group, self.version, self.namespace, plural, name)
+        except Exception as exc:  # pragma: no cover - log only
+            logging.error("read CR failed: %s", exc)
+            return {}
+
+    def patch_cr(self, plural: str, name: str, spec: Dict) -> None:
+        body = {"spec": spec}
+        try:
+            self.api.patch_namespaced_custom_object(
+                self.group, self.version, self.namespace, plural, name, body)
+        except Exception as exc:  # pragma: no cover - log only
+            logging.error("patch CR failed: %s", exc)
+
+    def sync_once(self) -> None:
+        for path, (plural, name) in self.file_map.items():
+            file_data = self.load_file(path)
+            cr_obj = self.read_cr(plural, name)
+            cr_spec = cr_obj.get('spec', {})
+
+            file_hash = hash_dict(file_data) if file_data else None
+            cr_hash = hash_dict(cr_spec) if cr_spec else None
+            last = self.state[path]
+
+            if last['file'] is None and last['cr'] is None:
+                if file_hash:
+                    logging.info('initial sync: file -> CR for %s', path)
+                    self.patch_cr(plural, name, file_data)
+                    self.state[path] = {'file': file_hash, 'cr': file_hash}
+                elif cr_hash:
+                    logging.info('initial sync: CR -> file for %s', path)
+                    self.write_file(path, cr_spec)
+                    self.state[path] = {'file': cr_hash, 'cr': cr_hash}
+                continue
+
+            if file_hash != last['file']:
+                logging.info('file changed: updating CR %s/%s', plural, name)
+                self.patch_cr(plural, name, file_data)
+                self.state[path] = {'file': file_hash, 'cr': file_hash}
+            elif cr_hash != last['cr']:
+                logging.info('CR changed: updating file %s', path)
+                self.write_file(path, cr_spec)
+                self.state[path] = {'file': cr_hash, 'cr': cr_hash}
+
+    def run(self) -> None:
+        while True:
+            self.sync_once()
+            time.sleep(self.interval)
+
+
+def main() -> None:
+    file_map_env = os.environ.get('FILE_MAP')
+    if not file_map_env:
+        raise SystemExit('FILE_MAP is required')
+
+    file_map = parse_file_map(file_map_env)
+    group = os.environ.get('CRD_GROUP', 'ha.example.com')
+    version = os.environ.get('CRD_VERSION', 'v1')
+    namespace = os.environ.get('CRD_NAMESPACE', 'default')
+    in_cluster = os.environ.get('IN_CLUSTER', 'true').lower() == 'true'
+    interval = int(os.environ.get('SYNC_INTERVAL', '5'))
+
+    load_kube_config(in_cluster)
+    api = client.CustomObjectsApi()
+
+    syncer = FileCRSyncer(file_map, api, group, version, namespace, interval)
+    syncer.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/crd-syncer/tests/test_syncer.py
+++ b/crd-syncer/tests/test_syncer.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from syncer.main import md5_bytes, hash_dict, FileCRSyncer
+
+
+class FakeAPI:
+    def __init__(self):
+        self.store = {}
+
+    def get_namespaced_custom_object(self, group, version, namespace, plural, name):
+        return self.store.get((plural, name), {})
+
+    def patch_namespaced_custom_object(self, group, version, namespace, plural, name, body):
+        self.store[(plural, name)] = body
+
+
+def test_hash():
+    h1 = hash_dict({"a": 1})
+    h2 = hash_dict({"a": 1})
+    h3 = hash_dict({"a": 2})
+    assert h1 == h2
+    assert h1 != h3
+    assert md5_bytes(b"abc") == "900150983cd24fb0d6963f7d28e17f72"
+
+
+def test_file_io(tmp_path):
+    path = tmp_path / "state.json"
+    data = {"foo": "bar"}
+    syncer = FileCRSyncer({}, FakeAPI(), "g", "v", "n")
+    syncer.write_file(str(path), data)
+    assert path.exists()
+    loaded = syncer.load_file(str(path))
+    assert loaded == data
+
+
+def test_sync_file_to_cr(tmp_path):
+    path = tmp_path / "state.json"
+    data = {"foo": "bar"}
+    path.write_text(json.dumps(data))
+    api = FakeAPI()
+    file_map = {str(path): ("states", "example")}
+    syncer = FileCRSyncer(file_map, api, "g", "v", "n")
+    syncer.sync_once()
+    assert api.store[("states", "example")] == {"spec": data}


### PR DESCRIPTION
## Summary
- implement syncer with MD5-based two-way sync between JSON files and Kubernetes CRs
- add Dockerfile, deployment manifests, and documentation
- provide tests for hashing, file I/O, and mocked K8s API

## Testing
- `pip install -r crd-syncer/requirements.txt`
- `PYTHONPATH=crd-syncer pytest -q crd-syncer/tests/test_syncer.py`


------
https://chatgpt.com/codex/tasks/task_e_689396ae83648331931405eaeee026b4